### PR TITLE
Add options.parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Creates a new `tap-to-start` overlay. Accepts the following options:
 * `background`: the color of the background. Defaults to `transparent`.
 * `accent`: the color of the tap icon. Defaults to `background`, or `#fff` if not specified.
 * `skip`: if truthy, skip the UI and call `done` in the next frame. Useful if you only want the UI to be visible if user input is required to continue.
+* `parent`: optional, defaults to `document.body`. Set the element the button is attached to
 
 `done` is called when the UI is tapped/clicked and begins to transition out.
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function tapToStart (options, done) {
   var bgColor = options.background || 'transparent'
   var fgColor = options.foreground || '#000'
   var acColor = options.accent || options.background || '#fff'
+  var parentEl = options.parent || document.body
   if (options.skip) return raf(done)
 
   var container = SVG('svg')
@@ -47,7 +48,7 @@ function tapToStart (options, done) {
   render()
   resize()
 
-  document.body.appendChild(container)
+  parentEl.appendChild(container)
 
   window.addEventListener('resize', resize, false)
   window.addEventListener('touchstart', tap, false)


### PR DESCRIPTION
Adds the `options.parent` setting which allows the button to be rendered
on targets other than `document.body`. Thanks! :grin:

Closes GH-2

P.s. the lil octo wiggle is the cutest haha
